### PR TITLE
Add tests for VCR Serializer and Persister

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.3.0
+  - 2.1.10
+  - 2.2.5
+  - 2.3.1
 before_install: gem install bundler -v 1.12.5
+cache: bundler

--- a/lib/vcr/archive.rb
+++ b/lib/vcr/archive.rb
@@ -11,7 +11,7 @@ module VCR
 
     class Serializer
       def self.file_extension
-        'git'
+        'archive'
       end
 
       def self.serialize(hash)
@@ -22,7 +22,6 @@ module VCR
         hash
       end
     end
-
 
     module Persister
       extend self

--- a/lib/vcr/archive.rb
+++ b/lib/vcr/archive.rb
@@ -1,4 +1,5 @@
 require 'vcr'
+require 'yaml'
 
 require 'vcr/archive/version'
 
@@ -28,16 +29,61 @@ module VCR
     module Persister
       extend self
 
-      def [](_)
-        nil
+      attr_reader :storage_location
+
+      def storage_location=(dir)
+        FileUtils.mkdir_p(dir) if dir
+        @storage_location = dir ? absolute_path_for(dir) : nil
       end
 
-      def []=(_, _)
-        nil
+      def [](file_name)
+        path = absolute_path_to_file(file_name)
+        files = Dir.glob("#{path}/**/*.yml")
+        return nil unless files.any?
+        interactions = files.map do |f|
+          meta = YAML.load_file(f)
+          body = File.binread(f.sub(/\.yml$/, '.html'))
+          meta['response']['body']['string'] = body
+          meta
+        end
+        {
+          'http_interactions' => interactions,
+        }
       end
 
-      def absolute_path_to_file(storage_key)
-        storage_key
+      def []=(file_name, meta)
+        path = absolute_path_to_file(file_name)
+        meta['http_interactions'].each do |interaction|
+          uri = URI.parse(interaction['request']['uri'])
+          path = File.join(path, uri.host, Digest::SHA1.hexdigest(uri.to_s))
+          directory = File.dirname(path)
+          FileUtils.mkdir_p(directory) unless File.exist?(directory)
+          body = interaction['response']['body'].delete('string')
+          File.binwrite("#{path}.yml", YAML.dump(interaction))
+          File.binwrite("#{path}.html", body)
+        end
+      end
+
+      def absolute_path_to_file(file_name)
+        return nil unless storage_location
+        File.join(storage_location, sanitized_file_name_from(file_name))
+      end
+
+      private
+
+      def absolute_path_for(path)
+        Dir.chdir(path) { Dir.pwd }
+      end
+
+      def sanitized_file_name_from(file_name)
+        parts = file_name.to_s.split('.')
+
+        # Get rid of the unneeded extension on the file_name
+        if parts.size > 1 && !parts.last.include?(File::SEPARATOR)
+          parts.pop
+        end
+
+        parts.join('.').gsub(/[^\w\-\/]+/, '_')
       end
     end
 

--- a/lib/vcr/archive.rb
+++ b/lib/vcr/archive.rb
@@ -9,16 +9,18 @@ module VCR
 
     attr_accessor :git_repository_url
 
-    class Serializer
-      def self.file_extension
+    module Serializer
+      extend self
+
+      def file_extension
         'archive'
       end
 
-      def self.serialize(hash)
+      def serialize(hash)
         hash
       end
 
-      def self.deserialize(hash)
+      def deserialize(hash)
         hash
       end
     end

--- a/test/vcr/archive_test.rb
+++ b/test/vcr/archive_test.rb
@@ -17,4 +17,69 @@ describe VCR::Archive do
       assert_equal({ foo: :bar }, subject.deserialize(foo: :bar))
     end
   end
+
+  describe 'Persister' do
+    subject { VCR::Archive::Persister }
+
+    let(:tmpdir) { Dir.mktmpdir }
+    let(:uri) { 'http://example.org' }
+    let(:meta) do
+      {
+        'http_interactions' => [
+          {
+            'request' => {
+              'uri' => uri,
+            },
+            'response' => {
+              'body' => {
+                'string' => 'Hello, world.',
+              },
+            },
+          },
+        ],
+      }
+    end
+    let(:path) { File.join(tmpdir, 'foo', 'example.org', Digest::SHA1.hexdigest(uri)) }
+
+    before { subject.storage_location = tmpdir }
+
+    describe '#[]' do
+      let(:path) { subject.storage_location + '/foo/example.com/123' }
+      let(:yaml_path) { path + '.yml' }
+      let(:html_path) { path + '.html' }
+
+      before { FileUtils.mkdir_p(File.dirname(path)) }
+
+      it 'reads from the given file, relative to the configured storage location' do
+        File.write(yaml_path, YAML.dump(meta['http_interactions'].first))
+        html = '<p>Hello, world.</p>'
+        File.write(html_path, html)
+        meta['http_interactions'].first['response']['body']['string'] = html
+        assert_equal meta, subject['foo']
+      end
+
+      it 'returns nil if the directory does not exist' do
+        FileUtils.rm_rf(File.dirname(path))
+        assert_nil subject['bar']
+      end
+
+      it 'returns nil if the directory exists but is empty' do
+        FileUtils.mkdir_p(File.dirname(path))
+        assert_nil subject['foo']
+      end
+    end
+
+    describe '#[]=' do
+      it 'writes out response body to an html file' do
+        subject['foo'] = meta
+        assert_equal 'Hello, world.', File.read("#{path}.html")
+      end
+
+      it 'writes out the metadata to a yaml file' do
+        subject['foo'] = meta
+        expected = { 'request'=> { 'uri' => 'http://example.org' }, 'response' => { 'body' => {} } }
+        assert_equal expected, YAML.load_file("#{path}.yml")
+      end
+    end
+  end
 end

--- a/test/vcr/archive_test.rb
+++ b/test/vcr/archive_test.rb
@@ -1,8 +1,8 @@
 require 'test_helper'
 require 'open-uri'
 
-class VCR::ArchiveTest < Minitest::Test
-  def test_that_it_has_a_version_number
+describe VCR::Archive do
+  it 'has a version number' do
     refute_nil ::VCR::Archive::VERSION
   end
 end

--- a/test/vcr/archive_test.rb
+++ b/test/vcr/archive_test.rb
@@ -5,4 +5,16 @@ describe VCR::Archive do
   it 'has a version number' do
     refute_nil ::VCR::Archive::VERSION
   end
+
+  describe 'Serializer'  do
+    subject { VCR::Archive::Serializer }
+    it 'returns "archive" as the file extension' do
+      assert_equal 'archive', subject.file_extension
+    end
+
+    it "doesn't touch the hash when (de)serializing" do
+      assert_equal({ foo: :bar }, subject.serialize(foo: :bar))
+      assert_equal({ foo: :bar }, subject.deserialize(foo: :bar))
+    end
+  end
 end

--- a/vcr-archive.gemspec
+++ b/vcr-archive.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.12'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'minitest', '~> 5.0'
+  spec.add_development_dependency 'pry', '~> 0.10.4'
 end


### PR DESCRIPTION
As part of https://github.com/everypolitician/vcr-archive/issues/1 we want to add back the `Serializer` and `Persister` class, as they are core to just using the gem as a persistence mechanism.
