### PR TITLE
Add simplecov for reporting test coverage

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,6 @@
+require 'simplecov'
+SimpleCov.start if ENV['COVERAGE']
+
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'vcr/archive'
 

--- a/vcr-archive.gemspec
+++ b/vcr-archive.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'pry', '~> 0.10.4'
+  spec.add_development_dependency 'simplecov', '~> 0.12.0'
 end


### PR DESCRIPTION
If `ENV['COVERAGE']` is set this outputs the coverage at the end of test runs and generates an html version into the `coverage/` directory.
