### PR TITLE
Test that the Serializer file_extension is removed

### DIFF
--- a/lib/vcr/archive.rb
+++ b/lib/vcr/archive.rb
@@ -73,7 +73,7 @@ module VCR
         parts = file_name.to_s.split('.')
 
         # Get rid of the unneeded extension on the file_name
-        if parts.size > 1 && !parts.last.include?(File::SEPARATOR)
+        if parts.size > 1 && parts.last == Serializer.file_extension
           parts.pop
         end
 

--- a/test/vcr/archive_test.rb
+++ b/test/vcr/archive_test.rb
@@ -50,13 +50,27 @@ describe VCR::Archive do
 
       before { FileUtils.mkdir_p(File.dirname(path)) }
 
-      it 'reads from the given file, relative to the configured storage location' do
-        File.write(yaml_path, YAML.dump(meta['http_interactions'].first))
-        html = '<p>Hello, world.</p>'
-        File.write(html_path, html)
-        meta['http_interactions'].first['response']['body']['string'] = html
-        assert_equal meta, subject['foo']
+      describe 'existing files' do
+        before do
+          File.write(yaml_path, YAML.dump(meta['http_interactions'].first))
+          html = '<p>Hello, world.</p>'
+          File.write(html_path, html)
+          meta['http_interactions'].first['response']['body']['string'] = html
+        end
+
+        it 'reads from the given file, relative to the configured storage location' do
+          assert_equal meta, subject['foo']
+        end
+
+        it 'ignores the extension from the serializer' do
+          assert_equal meta, subject['foo.archive']
+        end
+
+        it 'returns nil for unknown extensions' do
+          assert_nil subject['foo.bar']
+        end
       end
+
 
       it 'returns nil if the directory does not exist' do
         FileUtils.rm_rf(File.dirname(path))


### PR DESCRIPTION
We don't need a file extension, since we're dealing with directories, so we remove the extension that comes from the `Serializer`.

The fact this wasn't tested and didn't actually work correctly came to light after adding the coverage in #4 .
